### PR TITLE
Add missing schemaVersion to CreateAuthModel method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.20' ]
+        go-version: [ '1.21' ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.20' ]
+        go-version: [ '1.21' ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/client.go
+++ b/client.go
@@ -56,12 +56,6 @@ type Client struct {
 	AuthModelId string
 }
 
-// jsonAuthModel represents the structure of an authorization model contained
-// in a json string.
-type jsonAuthModel struct {
-	TypeDefinitions []openfga.TypeDefinition `json:"type_definitions"`
-}
-
 // NewClient returns a wrapped OpenFGA API client ensuring all calls are made
 // to the provided authorisation model (id) and returns what is necessary.
 func NewClient(ctx context.Context, p OpenFGAParams) (*Client, error) {
@@ -295,9 +289,9 @@ func (c *Client) ReadChanges(ctx context.Context, entityType string, pageSize in
 }
 
 // AuthModelFromJSON converts the input json representation of an authorization
-// model into a slice of TypeDefinitions that can be used with the API.
-func AuthModelFromJSON(data []byte) ([]openfga.TypeDefinition, error) {
-	var parsed jsonAuthModel
+// model into an [AuthModel] that can be used with the API.
+func AuthModelFromJSON(data []byte) (*openfga.AuthorizationModel, error) {
+	var parsed openfga.AuthorizationModel
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal JSON auth model: %v", err)
 	}
@@ -306,15 +300,16 @@ func AuthModelFromJSON(data []byte) ([]openfga.TypeDefinition, error) {
 		return nil, fmt.Errorf(`"type_definitions" field not found`)
 	}
 
-	return parsed.TypeDefinitions, nil
+	return &parsed, nil
 }
 
 // CreateAuthModel creates a new authorization model as per the provided type
-// definitions and returns its ID. The [AuthModelFromJSON] function can be used
-// to convert an authorization model from json to the slice of type definitions
-// required by this method.
-func (c *Client) CreateAuthModel(ctx context.Context, authModel []openfga.TypeDefinition) (string, error) {
-	ar := openfga.NewWriteAuthorizationModelRequest(authModel)
+// definitions and schemaVersion and returns its ID. The [AuthModelFromJSON]
+// function can be used to convert an authorization model from json to the
+// slice of type definitions required by this method.
+func (c *Client) CreateAuthModel(ctx context.Context, authModel *openfga.AuthorizationModel) (string, error) {
+	ar := openfga.NewWriteAuthorizationModelRequest(*authModel.TypeDefinitions)
+	ar.SetSchemaVersion(authModel.SchemaVersion)
 	resp, _, err := c.api.WriteAuthorizationModel(ctx).Body(*ar).Execute()
 	if err != nil {
 		zapctx.Error(ctx, fmt.Sprintf("cannot execute WriteAuthorizationModel request: %v", err))

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -69,34 +69,37 @@ var (
 	  ],
 	  "schema_version": "1.1"
 	}`)
-	authModel = []openfga.TypeDefinition{
-		{Type: "user", Relations: &map[string]openfga.Userset{}},
-		{
-			Type: "document",
-			Relations: &map[string]openfga.Userset{
-				"writer": {
-					This: &map[string]interface{}{},
-				},
-				"viewer": {Union: &openfga.Usersets{
-					Child: &[]openfga.Userset{
-						{This: &map[string]interface{}{}},
-						{ComputedUserset: &openfga.ObjectRelation{
-							Object:   openfga.PtrString(""),
-							Relation: openfga.PtrString("writer"),
-						}},
-					},
-				}},
-			},
-			Metadata: &openfga.Metadata{
-				Relations: &map[string]openfga.RelationMetadata{
+	authModel = openfga.AuthorizationModel{
+		SchemaVersion: "1.1",
+		TypeDefinitions: &[]openfga.TypeDefinition{
+			{Type: "user", Relations: &map[string]openfga.Userset{}},
+			{
+				Type: "document",
+				Relations: &map[string]openfga.Userset{
 					"writer": {
-						DirectlyRelatedUserTypes: &[]openfga.RelationReference{
-							{Type: "user"},
-						},
+						This: &map[string]interface{}{},
 					},
-					"viewer": {
-						DirectlyRelatedUserTypes: &[]openfga.RelationReference{
-							{Type: "user"},
+					"viewer": {Union: &openfga.Usersets{
+						Child: &[]openfga.Userset{
+							{This: &map[string]interface{}{}},
+							{ComputedUserset: &openfga.ObjectRelation{
+								Object:   openfga.PtrString(""),
+								Relation: openfga.PtrString("writer"),
+							}},
+						},
+					}},
+				},
+				Metadata: &openfga.Metadata{
+					Relations: &map[string]openfga.RelationMetadata{
+						"writer": {
+							DirectlyRelatedUserTypes: &[]openfga.RelationReference{
+								{Type: "user"},
+							},
+						},
+						"viewer": {
+							DirectlyRelatedUserTypes: &[]openfga.RelationReference{
+								{Type: "user"},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Description

The method to create authorization models is missing the schemaVersion param due to which it is not possible to create auth models via the ofga library right now. This PR addresses updates the createAuthModel method to add this missing parameter.

Fixes [CSS-5147](https://warthogs.atlassian.net/browse/CSS-5147)

