### PR TITLE
Add method to add and remove relations atomically

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -204,6 +204,26 @@ func ExampleClient_RemoveRelation_multiple() {
 	}
 }
 
+func ExampleClient_ModifyRelations() {
+	// Modify a user's relation with a document from viewer to editor.
+	addTuples := []ofga.Tuple{{
+		Object:   &ofga.Entity{Kind: "user", ID: "456"},
+		Relation: "editor",
+		Target:   &ofga.Entity{Kind: "document", ID: "ABC"},
+	}}
+	removeTuples := []ofga.Tuple{{
+		Object:   &ofga.Entity{Kind: "user", ID: "456"},
+		Relation: "viewer",
+		Target:   &ofga.Entity{Kind: "document", ID: "ABC"},
+	}}
+	// Add and remove tuples atomically.
+	err := client.ModifyRelations(context.Background(), addTuples, removeTuples)
+	if err != nil {
+		// Handle err
+		return
+	}
+}
+
 func ExampleClient_CreateStore() {
 	// Create a store named "Alpha"
 	storeID, err := client.CreateStore(context.Background(), "Alpha")

--- a/export_test.go
+++ b/export_test.go
@@ -4,7 +4,8 @@
 package ofga
 
 var (
-	ToOpenFGATuple                                  = (*Tuple).toOpenFGATuple
+	ToOpenFGATuple                                  = (*Tuple).toOpenFGATupleKey
+	TuplesToOpenFGATupleKeys                        = tuplesToOpenFGATupleKeys
 	TupleIsEmpty                                    = (*Tuple).isEmpty
 	FromOpenFGATupleKey                             = fromOpenFGATupleKey
 	ValidateTupleForFindMatchingTuples              = validateTupleForFindMatchingTuples

--- a/tuples.go
+++ b/tuples.go
@@ -78,8 +78,8 @@ type Tuple struct {
 	Target   *Entity
 }
 
-// toOpenFGATuple converts our Tuple struct into an OpenFGA TupleKey.
-func (t Tuple) toOpenFGATuple() openfga.TupleKey {
+// toOpenFGATupleKey converts our Tuple struct into an OpenFGA TupleKey.
+func (t Tuple) toOpenFGATupleKey() openfga.TupleKey {
 	k := openfga.NewTupleKey()
 	// In some cases, specifying the object is not required.
 	if t.Object != nil {
@@ -115,6 +115,15 @@ func fromOpenFGATupleKey(key openfga.TupleKey) (Tuple, error) {
 		Relation: Relation(key.GetRelation()),
 		Target:   &object,
 	}, nil
+}
+
+// tuplesToOpenFGATupleKeys converts a slice of tuples into OpenFGA Tuple Keys.
+func tuplesToOpenFGATupleKeys(tuples []Tuple) []openfga.TupleKey {
+	keys := make([]openfga.TupleKey, len(tuples))
+	for i, tuple := range tuples {
+		keys[i] = tuple.toOpenFGATupleKey()
+	}
+	return keys
 }
 
 // isEmpty is a helper method to check whether a tuple is set to a non-empty

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/canonical/ofga"
 )
 
-const relationEditor ofga.Relation = "editor"
+const (
+	relationEditor ofga.Relation = "editor"
+	relationViewer ofga.Relation = "viewer"
+)
 
 var (
 	entityTestUser     = ofga.Entity{Kind: "user", ID: "123"}

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -171,6 +171,52 @@ func TestToOpenFGATuple(t *testing.T) {
 	}
 }
 
+func TestTuplesToOpenFGATupleKeys(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		about                    string
+		tuples                   []ofga.Tuple
+		expectedOpenFGATupleKeys []openfga.TupleKey
+	}{{
+		about:                    "empty slice of tuples returns empty slice of tuple keys",
+		tuples:                   []ofga.Tuple{},
+		expectedOpenFGATupleKeys: []openfga.TupleKey{},
+	}, {
+		about: "tuples converted successfully",
+		tuples: []ofga.Tuple{{
+			Object:   &entityTestUser,
+			Relation: relationEditor,
+			Target:   &entityTestContract,
+		}, {
+			Relation: relationEditor,
+			Target:   &entityTestContract,
+		}, {
+			Target: &entityTestContract,
+		}},
+		expectedOpenFGATupleKeys: []openfga.TupleKey{{
+			User:     openfga.PtrString(entityTestUser.String()),
+			Relation: openfga.PtrString(relationEditor.String()),
+			Object:   openfga.PtrString(entityTestContract.String()),
+		}, {
+			Relation: openfga.PtrString(relationEditor.String()),
+			Object:   openfga.PtrString(entityTestContract.String()),
+		}, {
+			Object: openfga.PtrString(entityTestContract.String()),
+		}},
+	}}
+
+	for _, test := range tests {
+		test := test
+		c.Run(test.about, func(c *qt.C) {
+			c.Parallel()
+
+			tupleKeys := ofga.TuplesToOpenFGATupleKeys(test.tuples)
+			c.Assert(tupleKeys, qt.DeepEquals, test.expectedOpenFGATupleKeys)
+		})
+	}
+}
+
 func TestEntity_String(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Description

The library is currently missing a method that allows to atomically add and remove relations in a single transactional write. This PR adds a new method to provide exactly this functionality.

Closes [CSS-5412](https://warthogs.atlassian.net/browse/CSS-5412)



[CSS-5412]: https://warthogs.atlassian.net/browse/CSS-5412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ