### PR TITLE
Rename method name and refactor some implementations

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,18 +129,7 @@ func NewClient(ctx context.Context, p OpenFGAParams) (*Client, error) {
 // AddRelation adds the specified relation(s) between the objects & targets as
 // specified by the given tuple(s).
 func (c *Client) AddRelation(ctx context.Context, tuples ...Tuple) error {
-	wr := openfga.NewWriteRequest()
-	wr.SetAuthorizationModelId(c.AuthModelId)
-
-	tupleKeys := tuplesToOpenFGATupleKeys(tuples)
-	keys := openfga.NewTupleKeys(tupleKeys)
-	wr.SetWrites(*keys)
-	_, _, err := c.api.Write(ctx).Body(*wr).Execute()
-	if err != nil {
-		zapctx.Error(ctx, fmt.Sprintf("cannot execute Write request: %v", err))
-		return fmt.Errorf("cannot add relation: %v", err)
-	}
-	return nil
+	return c.AddRemoveRelations(ctx, tuples, nil)
 }
 
 // CheckRelation checks whether the specified relation exists (either directly
@@ -202,24 +191,13 @@ func (c *Client) checkRelation(ctx context.Context, tuple Tuple, trace bool, con
 // RemoveRelation removes the specified relation(s) between the objects &
 // targets as specified by the given tuples.
 func (c *Client) RemoveRelation(ctx context.Context, tuples ...Tuple) error {
-	wr := openfga.NewWriteRequest()
-	wr.SetAuthorizationModelId(c.AuthModelId)
-
-	tupleKeys := tuplesToOpenFGATupleKeys(tuples)
-	keys := openfga.NewTupleKeys(tupleKeys)
-	wr.SetDeletes(*keys)
-	_, _, err := c.api.Write(ctx).Body(*wr).Execute()
-	if err != nil {
-		zapctx.Error(ctx, fmt.Sprintf("cannot execute Write request: %v", err))
-		return fmt.Errorf("cannot remove relation: %v", err)
-	}
-	return nil
+	return c.AddRemoveRelations(ctx, nil, tuples)
 }
 
-// ModifyRelations adds and removes the specified relation tuples in a single
+// AddRemoveRelations adds and removes the specified relation tuples in a single
 // atomic write operation. If you want to solely add relations or solely remove
 // relations, consider using the AddRelation or RemoveRelation methods instead.
-func (c *Client) ModifyRelations(ctx context.Context, addTuples, removeTuples []Tuple) error {
+func (c *Client) AddRemoveRelations(ctx context.Context, addTuples, removeTuples []Tuple) error {
 	wr := openfga.NewWriteRequest()
 	wr.SetAuthorizationModelId(c.AuthModelId)
 
@@ -234,7 +212,7 @@ func (c *Client) ModifyRelations(ctx context.Context, addTuples, removeTuples []
 	_, _, err := c.api.Write(ctx).Body(*wr).Execute()
 	if err != nil {
 		zapctx.Error(ctx, fmt.Sprintf("cannot execute Write request: %v", err))
-		return fmt.Errorf("cannot modify relations: %v", err)
+		return fmt.Errorf("cannot add or remove relations: %v", err)
 	}
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -260,7 +260,7 @@ func TestClientAddRelation(t *testing.T) {
 			Route:              WriteRoute,
 			MockResponseStatus: http.StatusBadRequest,
 		}},
-		expectedErr: "cannot add relation.*",
+		expectedErr: "cannot add or remove relations.*",
 	}, {
 		about: "relation added successfully",
 		tuples: []ofga.Tuple{
@@ -579,7 +579,7 @@ func TestClientRemoveRelation(t *testing.T) {
 			Route:              WriteRoute,
 			MockResponseStatus: http.StatusInternalServerError,
 		}},
-		expectedErr: "cannot remove relation.*",
+		expectedErr: "cannot add or remove relation.*",
 	}, {
 		about: "relation removed successfully",
 		tuples: []ofga.Tuple{{
@@ -628,7 +628,7 @@ func TestClientRemoveRelation(t *testing.T) {
 	}
 }
 
-func TestClientModifyRelation(t *testing.T) {
+func TestClientAddRemoveRelations(t *testing.T) {
 	c := qt.New(t)
 
 	ctx := context.Background()
@@ -656,7 +656,7 @@ func TestClientModifyRelation(t *testing.T) {
 			Route:              WriteRoute,
 			MockResponseStatus: http.StatusInternalServerError,
 		}},
-		expectedErr: "cannot modify relations.*",
+		expectedErr: "cannot add or remove relations.*",
 	}, {
 		about: "relations added and removed successfully",
 		addTuples: []ofga.Tuple{{
@@ -699,7 +699,7 @@ func TestClientModifyRelation(t *testing.T) {
 			}
 
 			// Execute the test.
-			err := client.ModifyRelations(ctx, test.addTuples, test.removeTuples)
+			err := client.AddRemoveRelations(ctx, test.addTuples, test.removeTuples)
 
 			if test.expectedErr != "" {
 				c.Assert(err, qt.ErrorMatches, test.expectedErr)

--- a/example_test.go
+++ b/example_test.go
@@ -204,8 +204,9 @@ func ExampleClient_RemoveRelation_multiple() {
 	}
 }
 
-func ExampleClient_ModifyRelations() {
-	// Modify a user's relation with a document from viewer to editor.
+func ExampleClient_AddRemoveRelations() {
+	// Add and remove tuples to modify a user's relation with a document
+	// from viewer to editor.
 	addTuples := []ofga.Tuple{{
 		Object:   &ofga.Entity{Kind: "user", ID: "456"},
 		Relation: "editor",
@@ -217,7 +218,7 @@ func ExampleClient_ModifyRelations() {
 		Target:   &ofga.Entity{Kind: "document", ID: "ABC"},
 	}}
 	// Add and remove tuples atomically.
-	err := client.ModifyRelations(context.Background(), addTuples, removeTuples)
+	err := client.AddRemoveRelations(context.Background(), addTuples, removeTuples)
 	if err != nil {
 		// Handle err
 		return


### PR DESCRIPTION
## Description

- Rename `ModifyRelations` to `AddRemoveRelations` to be more precise. 
- Refactor `AddRelation` and `RemoveRelation` to call `AddRemoveRelations` instead of duplicating logic.