### PR TITLE
Expose functions that convert to OpenFGA tuples

### DIFF
--- a/client.go
+++ b/client.go
@@ -168,7 +168,7 @@ func (c *Client) checkRelation(ctx context.Context, tuple Tuple, trace bool, con
 		zap.Bool("trace", trace),
 		zap.Int("contextual tuples", len(contextualTuples)),
 	)
-	cr := openfga.NewCheckRequest(tuple.toOpenFGATupleKey())
+	cr := openfga.NewCheckRequest(tuple.ToOpenFGATupleKey())
 	cr.SetAuthorizationModelId(c.AuthModelId)
 
 	if len(contextualTuples) > 0 {
@@ -382,7 +382,7 @@ func (c *Client) FindMatchingTuples(ctx context.Context, tuple Tuple, pageSize i
 		if err := validateTupleForFindMatchingTuples(tuple); err != nil {
 			return nil, "", fmt.Errorf("invalid tuple for FindMatchingTuples: %v", err)
 		}
-		rr.SetTupleKey(tuple.toOpenFGATupleKey())
+		rr.SetTupleKey(tuple.ToOpenFGATupleKey())
 	}
 	if pageSize != 0 {
 		rr.SetPageSize(pageSize)
@@ -397,7 +397,7 @@ func (c *Client) FindMatchingTuples(ctx context.Context, tuple Tuple, pageSize i
 	}
 	tuples := make([]TimestampedTuple, 0, len(resp.GetTuples()))
 	for _, oTuple := range resp.GetTuples() {
-		t, err := fromOpenFGATupleKey(*oTuple.Key)
+		t, err := FromOpenFGATupleKey(*oTuple.Key)
 		if err != nil {
 			zapctx.Error(ctx, fmt.Sprintf("cannot parse tuple from Read response: %v", err))
 			return nil, "", fmt.Errorf("cannot parse tuple %+v, %v", oTuple, err)
@@ -477,7 +477,7 @@ func (c *Client) findUsersByRelation(ctx context.Context, tuple Tuple, maxDepth 
 		}, nil
 	}
 
-	er := openfga.NewExpandRequest(tuple.toOpenFGATupleKey())
+	er := openfga.NewExpandRequest(tuple.ToOpenFGATupleKey())
 	er.SetAuthorizationModelId(c.AuthModelId)
 	resp, _, err := c.api.Expand(ctx).Body(*er).Execute()
 	if err != nil {
@@ -615,7 +615,7 @@ func (c *Client) expand(ctx context.Context, maxDepth int, userStrings ...string
 			t := openfga.NewTupleKey()
 			t.SetRelation(tokens[1])
 			t.SetObject(tokens[0])
-			tuple, err := fromOpenFGATupleKey(*t)
+			tuple, err := FromOpenFGATupleKey(*t)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse tuple %s, %v", u, err)
 			}

--- a/export_test.go
+++ b/export_test.go
@@ -4,10 +4,8 @@
 package ofga
 
 var (
-	ToOpenFGATuple                                  = (*Tuple).toOpenFGATupleKey
 	TuplesToOpenFGATupleKeys                        = tuplesToOpenFGATupleKeys
 	TupleIsEmpty                                    = (*Tuple).isEmpty
-	FromOpenFGATupleKey                             = fromOpenFGATupleKey
 	ValidateTupleForFindMatchingTuples              = validateTupleForFindMatchingTuples
 	ValidateTupleForFindUsersByRelation             = validateTupleForFindUsersByRelation
 	FindUsersByRelationInternal                     = (*Client).findUsersByRelation

--- a/tuples.go
+++ b/tuples.go
@@ -78,8 +78,8 @@ type Tuple struct {
 	Target   *Entity
 }
 
-// toOpenFGATupleKey converts our Tuple struct into an OpenFGA TupleKey.
-func (t Tuple) toOpenFGATupleKey() openfga.TupleKey {
+// ToOpenFGATupleKey converts our Tuple struct into an OpenFGA TupleKey.
+func (t Tuple) ToOpenFGATupleKey() openfga.TupleKey {
 	k := openfga.NewTupleKey()
 	// In some cases, specifying the object is not required.
 	if t.Object != nil {
@@ -93,8 +93,8 @@ func (t Tuple) toOpenFGATupleKey() openfga.TupleKey {
 	return *k
 }
 
-// fromOpenFGATupleKey converts an openfga.TupleKey struct into a Tuple.
-func fromOpenFGATupleKey(key openfga.TupleKey) (Tuple, error) {
+// FromOpenFGATupleKey converts an openfga.TupleKey struct into a Tuple.
+func FromOpenFGATupleKey(key openfga.TupleKey) (Tuple, error) {
 	var user, object Entity
 	var err error
 	if key.HasUser() {
@@ -121,7 +121,7 @@ func fromOpenFGATupleKey(key openfga.TupleKey) (Tuple, error) {
 func tuplesToOpenFGATupleKeys(tuples []Tuple) []openfga.TupleKey {
 	keys := make([]openfga.TupleKey, len(tuples))
 	for i, tuple := range tuples {
-		keys[i] = tuple.toOpenFGATupleKey()
+		keys[i] = tuple.ToOpenFGATupleKey()
 	}
 	return keys
 }

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -165,7 +165,7 @@ func TestToOpenFGATuple(t *testing.T) {
 		c.Run(test.about, func(c *qt.C) {
 			c.Parallel()
 
-			tupleKey := ofga.ToOpenFGATuple(&test.tuple)
+			tupleKey := test.tuple.ToOpenFGATupleKey()
 			c.Assert(tupleKey, qt.DeepEquals, test.expectedOpenFGATupleKey)
 		})
 	}


### PR DESCRIPTION
## Description

There are certain functions defined in the library that convert between the library's tuple representation and OpenFGA tuple representations. This PR makes these methods public.

