### PR TITLE
Add methods to view/update certain client configs

### DIFF
--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ type OpenFgaApi interface {
 // Store and AuthorizationModel if such IDs are provided during configuration.
 type Client struct {
 	api         OpenFgaApi
-	authModelId string
+	authModelID string
 	getStoreID  func() string
 	setStoreID  func(storeID string)
 }
@@ -124,24 +124,24 @@ func NewClient(ctx context.Context, p OpenFGAParams) (*Client, error) {
 	}
 	return &Client{
 		api:         api,
-		authModelId: p.AuthModelID,
+		authModelID: p.AuthModelID,
 		getStoreID:  client.GetStoreId,
 		setStoreID:  client.SetStoreId,
 	}, nil
 }
 
-// GetAuthModelID gets the currently configured authorization model ID.
-func (c *Client) GetAuthModelID() string {
-	return c.authModelId
+// AuthModelID returns the currently configured authorization model ID.
+func (c *Client) AuthModelID() string {
+	return c.authModelID
 }
 
 // SetAuthModelID sets the authorization model ID to be used by the client.
 func (c *Client) SetAuthModelID(authModelID string) {
-	c.authModelId = authModelID
+	c.authModelID = authModelID
 }
 
-// GetStoreID gets the currently configured store ID.
-func (c *Client) GetStoreID() string {
+// StoreID gets the currently configured store ID.
+func (c *Client) StoreID() string {
 	return c.getStoreID()
 }
 
@@ -193,7 +193,7 @@ func (c *Client) checkRelation(ctx context.Context, tuple Tuple, trace bool, con
 		zap.Int("contextual tuples", len(contextualTuples)),
 	)
 	cr := openfga.NewCheckRequest(tuple.ToOpenFGATupleKey())
-	cr.SetAuthorizationModelId(c.authModelId)
+	cr.SetAuthorizationModelId(c.authModelID)
 
 	if len(contextualTuples) > 0 {
 		keys := tuplesToOpenFGATupleKeys(contextualTuples)
@@ -223,7 +223,7 @@ func (c *Client) RemoveRelation(ctx context.Context, tuples ...Tuple) error {
 // relations, consider using the AddRelation or RemoveRelation methods instead.
 func (c *Client) AddRemoveRelations(ctx context.Context, addTuples, removeTuples []Tuple) error {
 	wr := openfga.NewWriteRequest()
-	wr.SetAuthorizationModelId(c.authModelId)
+	wr.SetAuthorizationModelId(c.authModelID)
 
 	if len(addTuples) > 0 {
 		addTupleKeys := tuplesToOpenFGATupleKeys(addTuples)
@@ -502,7 +502,7 @@ func (c *Client) findUsersByRelation(ctx context.Context, tuple Tuple, maxDepth 
 	}
 
 	er := openfga.NewExpandRequest(tuple.ToOpenFGATupleKey())
-	er.SetAuthorizationModelId(c.authModelId)
+	er.SetAuthorizationModelId(c.authModelID)
 	resp, _, err := c.api.Expand(ctx).Body(*er).Execute()
 	if err != nil {
 		zapctx.Error(ctx, fmt.Sprintf("cannot execute Expand request: %v", err))
@@ -696,7 +696,7 @@ func (c *Client) FindAccessibleObjectsByRelation(ctx context.Context, tuple Tupl
 	}
 
 	lor := openfga.NewListObjectsRequestWithDefaults()
-	lor.SetAuthorizationModelId(c.authModelId)
+	lor.SetAuthorizationModelId(c.authModelID)
 	lor.SetUser(tuple.Object.String())
 	lor.SetRelation(tuple.Relation.String())
 	lor.SetType(tuple.Target.Kind.String())

--- a/client.go
+++ b/client.go
@@ -53,7 +53,9 @@ type OpenFgaApi interface {
 // Store and AuthorizationModel if such IDs are provided during configuration.
 type Client struct {
 	api         OpenFgaApi
-	AuthModelId string
+	authModelId string
+	getStoreID  func() string
+	setStoreID  func(storeID string)
 }
 
 // NewClient returns a wrapped OpenFGA API client ensuring all calls are made
@@ -122,8 +124,30 @@ func NewClient(ctx context.Context, p OpenFGAParams) (*Client, error) {
 	}
 	return &Client{
 		api:         api,
-		AuthModelId: p.AuthModelID,
+		authModelId: p.AuthModelID,
+		getStoreID:  client.GetStoreId,
+		setStoreID:  client.SetStoreId,
 	}, nil
+}
+
+// GetAuthModelID gets the currently configured authorization model ID.
+func (c *Client) GetAuthModelID() string {
+	return c.authModelId
+}
+
+// SetAuthModelID sets the authorization model ID to be used by the client.
+func (c *Client) SetAuthModelID(authModelID string) {
+	c.authModelId = authModelID
+}
+
+// GetStoreID gets the currently configured store ID.
+func (c *Client) GetStoreID() string {
+	return c.getStoreID()
+}
+
+// SetStoreID sets the store ID to be used by the client.
+func (c *Client) SetStoreID(storeID string) {
+	c.setStoreID(storeID)
 }
 
 // AddRelation adds the specified relation(s) between the objects & targets as
@@ -169,7 +193,7 @@ func (c *Client) checkRelation(ctx context.Context, tuple Tuple, trace bool, con
 		zap.Int("contextual tuples", len(contextualTuples)),
 	)
 	cr := openfga.NewCheckRequest(tuple.ToOpenFGATupleKey())
-	cr.SetAuthorizationModelId(c.AuthModelId)
+	cr.SetAuthorizationModelId(c.authModelId)
 
 	if len(contextualTuples) > 0 {
 		keys := tuplesToOpenFGATupleKeys(contextualTuples)
@@ -199,7 +223,7 @@ func (c *Client) RemoveRelation(ctx context.Context, tuples ...Tuple) error {
 // relations, consider using the AddRelation or RemoveRelation methods instead.
 func (c *Client) AddRemoveRelations(ctx context.Context, addTuples, removeTuples []Tuple) error {
 	wr := openfga.NewWriteRequest()
-	wr.SetAuthorizationModelId(c.AuthModelId)
+	wr.SetAuthorizationModelId(c.authModelId)
 
 	if len(addTuples) > 0 {
 		addTupleKeys := tuplesToOpenFGATupleKeys(addTuples)
@@ -478,7 +502,7 @@ func (c *Client) findUsersByRelation(ctx context.Context, tuple Tuple, maxDepth 
 	}
 
 	er := openfga.NewExpandRequest(tuple.ToOpenFGATupleKey())
-	er.SetAuthorizationModelId(c.AuthModelId)
+	er.SetAuthorizationModelId(c.authModelId)
 	resp, _, err := c.api.Expand(ctx).Body(*er).Execute()
 	if err != nil {
 		zapctx.Error(ctx, fmt.Sprintf("cannot execute Expand request: %v", err))
@@ -672,7 +696,7 @@ func (c *Client) FindAccessibleObjectsByRelation(ctx context.Context, tuple Tupl
 	}
 
 	lor := openfga.NewListObjectsRequestWithDefaults()
-	lor.SetAuthorizationModelId(c.AuthModelId)
+	lor.SetAuthorizationModelId(c.authModelId)
 	lor.SetUser(tuple.Object.String())
 	lor.SetRelation(tuple.Relation.String())
 	lor.SetType(tuple.Target.Kind.String())

--- a/client_test.go
+++ b/client_test.go
@@ -93,7 +93,7 @@ func getTestClient(c *qt.C) *ofga.Client {
 	// Create a client.
 	newClient, err := ofga.NewClient(context.Background(), validFGAParams)
 	c.Assert(err, qt.IsNil)
-	c.Assert(newClient.GetAuthModelID(), qt.Equals, validFGAParams.AuthModelID)
+	c.Assert(newClient.AuthModelID(), qt.Equals, validFGAParams.AuthModelID)
 
 	for _, cr := range clientCreationRoutes {
 		cr.Finish(c)
@@ -225,7 +225,7 @@ func TestNewClient(t *testing.T) {
 				c.Assert(client, qt.IsNil)
 			} else {
 				c.Assert(err, qt.IsNil)
-				c.Assert(client.GetAuthModelID(), qt.Equals, test.expectedAuthModelID)
+				c.Assert(client.AuthModelID(), qt.Equals, test.expectedAuthModelID)
 			}
 
 			// Validate that the mock routes were called as expected.
@@ -352,11 +352,11 @@ func TestClientUpdateStoreIDAndAuthModelID(t *testing.T) {
 			// Execute the test.
 			if test.updateStoreID != "" {
 				client.SetStoreID(test.updateStoreID)
-				c.Assert(client.GetStoreID(), qt.Equals, test.updateStoreID)
+				c.Assert(client.StoreID(), qt.Equals, test.updateStoreID)
 			}
 			if test.updateAuthModelID != "" {
 				client.SetAuthModelID(test.updateAuthModelID)
-				c.Assert(client.GetAuthModelID(), qt.Equals, test.updateAuthModelID)
+				c.Assert(client.AuthModelID(), qt.Equals, test.updateAuthModelID)
 			}
 			err := client.AddRelation(ctx, test.tuples...)
 			c.Assert(err, qt.IsNil)

--- a/client_test.go
+++ b/client_test.go
@@ -93,7 +93,7 @@ func getTestClient(c *qt.C) *ofga.Client {
 	// Create a client.
 	newClient, err := ofga.NewClient(context.Background(), validFGAParams)
 	c.Assert(err, qt.IsNil)
-	c.Assert(newClient.AuthModelId, qt.Equals, validFGAParams.AuthModelID)
+	c.Assert(newClient.GetAuthModelID(), qt.Equals, validFGAParams.AuthModelID)
 
 	for _, cr := range clientCreationRoutes {
 		cr.Finish(c)
@@ -225,8 +225,141 @@ func TestNewClient(t *testing.T) {
 				c.Assert(client, qt.IsNil)
 			} else {
 				c.Assert(err, qt.IsNil)
-				c.Assert(client.AuthModelId, qt.Equals, test.expectedAuthModelID)
+				c.Assert(client.GetAuthModelID(), qt.Equals, test.expectedAuthModelID)
 			}
+
+			// Validate that the mock routes were called as expected.
+			for _, mr := range test.mockRoutes {
+				mr.Finish(c)
+			}
+		})
+	}
+}
+
+func TestClientUpdateStoreIDAndAuthModelID(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		about string
+
+		mockRoutes []*mockhttp.RouteResponder
+
+		tuples            []ofga.Tuple
+		updateStoreID     string
+		updateAuthModelID string
+	}{{
+		about: "success: no configuration change",
+		tuples: []ofga.Tuple{
+			{
+				Object:   &entityTestUser,
+				Relation: relationEditor,
+				Target:   &entityTestContract,
+			},
+		},
+		mockRoutes: []*mockhttp.RouteResponder{{
+			Route:              WriteRoute,
+			ExpectedPathParams: []string{validFGAParams.StoreID},
+			ExpectedReqBody: openfga.WriteRequest{
+				Writes: openfga.NewTupleKeys([]openfga.TupleKey{{
+					User:     openfga.PtrString(entityTestUser.String()),
+					Relation: openfga.PtrString(relationEditor.String()),
+					Object:   openfga.PtrString(entityTestContract.String()),
+				}}),
+				AuthorizationModelId: openfga.PtrString(validFGAParams.AuthModelID),
+			},
+		}},
+	}, {
+		about:         "success: storeID changed",
+		updateStoreID: "AnotherStoreID",
+		tuples: []ofga.Tuple{
+			{
+				Object:   &entityTestUser,
+				Relation: relationEditor,
+				Target:   &entityTestContract,
+			},
+		},
+		mockRoutes: []*mockhttp.RouteResponder{{
+			Route:              WriteRoute,
+			ExpectedPathParams: []string{"AnotherStoreID"},
+			ExpectedReqBody: openfga.WriteRequest{
+				Writes: openfga.NewTupleKeys([]openfga.TupleKey{{
+					User:     openfga.PtrString(entityTestUser.String()),
+					Relation: openfga.PtrString(relationEditor.String()),
+					Object:   openfga.PtrString(entityTestContract.String()),
+				}}),
+				AuthorizationModelId: openfga.PtrString(validFGAParams.AuthModelID),
+			},
+		}},
+	}, {
+		about:             "success: authModelID changed",
+		updateAuthModelID: "AuthModel3000",
+		tuples: []ofga.Tuple{
+			{
+				Object:   &entityTestUser,
+				Relation: relationEditor,
+				Target:   &entityTestContract,
+			},
+		},
+		mockRoutes: []*mockhttp.RouteResponder{{
+			Route:              WriteRoute,
+			ExpectedPathParams: []string{validFGAParams.StoreID},
+			ExpectedReqBody: openfga.WriteRequest{
+				Writes: openfga.NewTupleKeys([]openfga.TupleKey{{
+					User:     openfga.PtrString(entityTestUser.String()),
+					Relation: openfga.PtrString(relationEditor.String()),
+					Object:   openfga.PtrString(entityTestContract.String()),
+				}}),
+				AuthorizationModelId: openfga.PtrString("AuthModel3000"),
+			},
+		}},
+	}, {
+		about:             "success: storeID and authModelID changed",
+		updateStoreID:     "AnotherStoreID",
+		updateAuthModelID: "AuthModel3000",
+		tuples: []ofga.Tuple{
+			{
+				Object:   &entityTestUser,
+				Relation: relationEditor,
+				Target:   &entityTestContract,
+			},
+		},
+		mockRoutes: []*mockhttp.RouteResponder{{
+			Route:              WriteRoute,
+			ExpectedPathParams: []string{"AnotherStoreID"},
+			ExpectedReqBody: openfga.WriteRequest{
+				Writes: openfga.NewTupleKeys([]openfga.TupleKey{{
+					User:     openfga.PtrString(entityTestUser.String()),
+					Relation: openfga.PtrString(relationEditor.String()),
+					Object:   openfga.PtrString(entityTestContract.String()),
+				}}),
+				AuthorizationModelId: openfga.PtrString("AuthModel3000"),
+			},
+		}},
+	}}
+	for _, test := range tests {
+		test := test
+		c.Run(test.about, func(c *qt.C) {
+			client := getTestClient(c)
+
+			// Set up and configure mock http responders.
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			for _, mr := range test.mockRoutes {
+				httpmock.RegisterResponder(mr.Route.Method, mr.Route.Endpoint, mr.Generate())
+			}
+
+			// Execute the test.
+			if test.updateStoreID != "" {
+				client.SetStoreID(test.updateStoreID)
+				c.Assert(client.GetStoreID(), qt.Equals, test.updateStoreID)
+			}
+			if test.updateAuthModelID != "" {
+				client.SetAuthModelID(test.updateAuthModelID)
+				c.Assert(client.GetAuthModelID(), qt.Equals, test.updateAuthModelID)
+			}
+			err := client.AddRelation(ctx, test.tuples...)
+			c.Assert(err, qt.IsNil)
 
 			// Validate that the mock routes were called as expected.
 			for _, mr := range test.mockRoutes {

--- a/example_test.go
+++ b/example_test.go
@@ -53,7 +53,7 @@ func ExampleNewClient() {
 		// Handle err
 		return
 	}
-	fmt.Printf(client.AuthModelId)
+	fmt.Print(client.GetAuthModelID())
 }
 
 func ExampleClient_AddRelation() {

--- a/example_test.go
+++ b/example_test.go
@@ -53,7 +53,7 @@ func ExampleNewClient() {
 		// Handle err
 		return
 	}
-	fmt.Print(client.GetAuthModelID())
+	fmt.Print(client.AuthModelID())
 }
 
 func ExampleClient_AddRelation() {


### PR DESCRIPTION
## Description

Adds methods to update and view the current `storeID` and `authModelID` being used by an existing `ofga` client.

Closes [CSS-5879](https://warthogs.atlassian.net/browse/CSS-5879)

[CSS-5879]: https://warthogs.atlassian.net/browse/CSS-5879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ