### PR TITLE
Add public access capability

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -415,6 +415,27 @@ func TestClientAddRelation(t *testing.T) {
 				AuthorizationModelId: openfga.PtrString(validFGAParams.AuthModelID),
 			},
 		}},
+	}, {
+		about: "wildcard relation added successfully",
+		tuples: []ofga.Tuple{
+			{
+				Object:   &publicEntityUser,
+				Relation: relationEditor,
+				Target:   &entityTestContract,
+			},
+		},
+		mockRoutes: []*mockhttp.RouteResponder{{
+			Route:              WriteRoute,
+			ExpectedPathParams: []string{validFGAParams.StoreID},
+			ExpectedReqBody: openfga.WriteRequest{
+				Writes: openfga.NewTupleKeys([]openfga.TupleKey{{
+					User:     openfga.PtrString(publicEntityUser.String()),
+					Relation: openfga.PtrString(relationEditor.String()),
+					Object:   openfga.PtrString(entityTestContract.String()),
+				}}),
+				AuthorizationModelId: openfga.PtrString(validFGAParams.AuthModelID),
+			},
+		}},
 	}}
 
 	for _, test := range tests {

--- a/tuples.go
+++ b/tuples.go
@@ -39,6 +39,7 @@ type Entity struct {
 	Relation Relation
 }
 
+// IsPublicAccess returns true when the entity ID is the * wildcard, representing any entity.
 func (t Entity) IsPublicAccess() bool {
 	return t.ID == "*"
 }

--- a/tuples.go
+++ b/tuples.go
@@ -13,7 +13,7 @@ import (
 
 // entityRegex is used to validate that a string represents an Entity/EntitySet
 // and helps to convert from a string representation into an Entity struct.
-var entityRegex = regexp.MustCompile(`([A-za-z0-9_][A-za-z0-9_-]*):([A-za-z0-9_][A-za-z0-9_@.+-]*)(#([A-za-z0-9_][A-za-z0-9_-]*))?`)
+var entityRegex = regexp.MustCompile(`([A-za-z0-9_][A-za-z0-9_-]*):([A-za-z0-9_*][A-za-z0-9_@.+-]*)(#([A-za-z0-9_][A-za-z0-9_-]*))?`)
 
 // Kind represents the type of the entity in OpenFGA.
 type Kind string
@@ -37,6 +37,10 @@ type Entity struct {
 	Kind     Kind
 	ID       string
 	Relation Relation
+}
+
+func (t Entity) IsPublicAccess() bool {
+	return t.ID == "*"
 }
 
 // String returns a string representation of the entity/entity-set.

--- a/tuples.go
+++ b/tuples.go
@@ -13,7 +13,7 @@ import (
 
 // entityRegex is used to validate that a string represents an Entity/EntitySet
 // and helps to convert from a string representation into an Entity struct.
-var entityRegex = regexp.MustCompile(`([A-za-z0-9_][A-za-z0-9_-]*):([A-za-z0-9_*][A-za-z0-9_@.+-]*)(#([A-za-z0-9_][A-za-z0-9_-]*))?`)
+var entityRegex = regexp.MustCompile(`([A-Za-z0-9_][A-Za-z0-9_-]*):([A-Za-z0-9_][A-Za-z0-9_@.+-]*|[*])(#([A-Za-z0-9_][A-Za-z0-9_-]*))?`)
 
 // Kind represents the type of the entity in OpenFGA.
 type Kind string

--- a/tuples.go
+++ b/tuples.go
@@ -13,7 +13,7 @@ import (
 
 // entityRegex is used to validate that a string represents an Entity/EntitySet
 // and helps to convert from a string representation into an Entity struct.
-var entityRegex = regexp.MustCompile(`([A-Za-z0-9_][A-Za-z0-9_-]*):([A-Za-z0-9_][A-Za-z0-9_@.+-]*|[*])(#([A-Za-z0-9_][A-Za-z0-9_-]*))?`)
+var entityRegex = regexp.MustCompile(`([A-Za-z0-9_][A-Za-z0-9_-]*):([A-Za-z0-9_][A-Za-z0-9_@.+-]*|[*])(#([A-Za-z0-9_][A-Za-z0-9_-]*))?$`)
 
 // Kind represents the type of the entity in OpenFGA.
 type Kind string

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -311,6 +311,10 @@ func TestParseEntity(t *testing.T) {
 			ID:       "*",
 			Relation: "member",
 		},
+	}, {
+		about:        "wildcard entity with extra characters raises an error",
+		entityString: "user:*foo",
+		expectedErr:  "invalid entity representation.*",
 	}}
 
 	for _, test := range tests {

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -20,6 +20,7 @@ const (
 var (
 	entityTestUser     = ofga.Entity{Kind: "user", ID: "123"}
 	entityTestUser2    = ofga.Entity{Kind: "user2", ID: "456"}
+	publicEntityUser   = ofga.Entity{Kind: "user", ID: "*"}
 	entityTestContract = ofga.Entity{Kind: "contract", ID: "789"}
 	authModelJson      = []byte(`{
 	  "type_definitions": [
@@ -292,6 +293,22 @@ func TestParseEntity(t *testing.T) {
 		expectedEntity: ofga.Entity{
 			Kind:     "user",
 			ID:       "some.user-name+suffix@some.domain-name+suffix",
+			Relation: "member",
+		},
+	}, {
+		about:        "wildcard entity is parsed correctly",
+		entityString: "user:*",
+		expectedEntity: ofga.Entity{
+			Kind:     "user",
+			ID:       "*",
+			Relation: "",
+		},
+	}, {
+		about:        "wildcard entity with relation is parsed correctly",
+		entityString: "user:*#member",
+		expectedEntity: ofga.Entity{
+			Kind:     "user",
+			ID:       "*",
 			Relation: "member",
 		},
 	}}


### PR DESCRIPTION
## Description

The library is missing functionality for [public-access](https://openfga.dev/docs/modeling/public-access) i.e. the ability to add a tuple of the form `user:* <relation> <object>`. If the authorization model is designed to accept the * wildcard, then a tuple with * will allow access for all users and ensures any check of the form `can user alice access resource foo` will work without explicitly defining Alice's access.

I've added tests to confirm this works and also updated the regex expression to allow the wildcard character (I also cleaned up the regex where I think it should've been `A-Za-z` instead of `A-za-z`). 

One important note is that with the current regex match, the string `user:*abc#test` matches everything up to the * and the rest is discarded. Because the wildcard card should only ever be alone I tried to update the regex to enforce this and came up with the below which uses a negative lookahead match but unfortunately Go's stdlib regex parser [doesn't support](https://stackoverflow.com/questions/26771592/negative-look-ahead-in-go-regular-expressions) negative lookahead.
`([A-Za-z0-9_][A-Za-z0-9_-]*):([A-Za-z0-9_][A-Za-z0-9_@.+-]*|[*](?![^#]))(#([A-Za-z0-9_][A-Za-z0-9_-]*))?`

## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Independent change*

## Merging instructions

The preferred way of merging:
- [ ] Merge
- [x] Squash and Merge
- [ ] Rebase and Merge
