### PR TITLE
Allow specifying entities of the form `document:` for the Read API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.22' ]
+        go-version: [ '1.23' ]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(GOIMPORTS):
 	go install golang.org/x/tools/cmd/goimports@latest
 
 $(STATICCHECK):
-	go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+	go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
 
 $(GOVULNCHECK):
 	go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-        "github.com/openfga/go-sdk/telemetry"
+	"github.com/openfga/go-sdk/telemetry"
 
 	"github.com/canonical/ofga"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/ofga
 
-go 1.22
+go 1.23
 
 require (
 	github.com/frankban/quicktest v1.14.6

--- a/tuples.go
+++ b/tuples.go
@@ -13,7 +13,7 @@ import (
 
 // entityRegex is used to validate that a string represents an Entity/EntitySet
 // and helps to convert from a string representation into an Entity struct.
-var entityRegex = regexp.MustCompile(`([A-Za-z0-9_][A-Za-z0-9_-]*):([A-Za-z0-9_][A-Za-z0-9_@.+-]*|[*])(#([A-Za-z0-9_][A-Za-z0-9_-]*))?$`)
+var entityRegex = regexp.MustCompile(`([A-Za-z0-9_][A-Za-z0-9_-]*):(?:([A-Za-z0-9_][A-Za-z0-9_@.+-]*|[*])(#([A-Za-z0-9_][A-Za-z0-9_-]*))?)?$`)
 
 // Kind represents the type of the entity in OpenFGA.
 type Kind string
@@ -32,7 +32,8 @@ func (r Relation) String() string {
 }
 
 // Entity represents an entity/entity-set in OpenFGA.
-// Example: `user:<user-id>`, `org:<org-id>#member`
+// Example: `user:<user-id>`, `org:<org-id>#member`, `document:` (only kind
+// sometimes used in the Read API)
 type Entity struct {
 	Kind     Kind
 	ID       string
@@ -54,6 +55,8 @@ func (e *Entity) String() string {
 
 // ParseEntity will parse a string representation into an Entity. It expects to
 // find entities of the form:
+//   - <entityType>:
+//     eg. organization:
 //   - <entityType>:<ID>
 //     eg. organization:canonical
 //   - <entityType>:<ID>#<relationship-set>

--- a/tuples_test.go
+++ b/tuples_test.go
@@ -307,6 +307,12 @@ func TestParseEntity(t *testing.T) {
 			ID:   "canonical",
 		},
 	}, {
+		about:        "entity with only a type is parsed correctly",
+		entityString: "document:",
+		expectedEntity: ofga.Entity{
+			Kind: "document",
+		},
+	}, {
 		about:        "entity with a relation is parsed correctly",
 		entityString: "organization:canonical#member",
 		expectedEntity: ofga.Entity{


### PR DESCRIPTION
## Description

The current `parseEntity` function always expected to find a `entityType` and `ID` at the least. But the Read API allows specifying only a `entityType`. This PR fixes the `parseEntity` to also allow entities of the form `<entityType>:`

