### PR TITLE
feat: add CheckRelationWithContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ For example:
     ... // Perform action
     ```
 
+6. Use request-level condition context with conditioned contextual tuples:
+    ```go
+    contextualTuple := ofga.Tuple{
+        Object:    &ofga.Entity{Kind: "user", ID: "123"},
+        Relation:  "viewer",
+        Target:    &ofga.Entity{Kind: "report", ID: "quarterly"},
+        Condition: ofga.NewRelationshipCondition("can_grant"),
+    }
+
+    allowed, err = client.CheckRelationWithContext(
+        ctx,
+        ofga.Tuple{
+            Object:   &ofga.Entity{Kind: "user", ID: "123"},
+            Relation: "viewer",
+            Target:   &ofga.Entity{Kind: "report", ID: "quarterly"},
+        },
+        map[string]any{"grantable": true},
+        contextualTuple,
+    )
+    if err != nil {
+        // Handle error
+    }
+    if !allowed {
+        // Permission denied
+    }
+    ... // Perform action
+    ```
+
 ## Documentation
 
 The documentation for this package can be found on

--- a/client.go
+++ b/client.go
@@ -216,6 +216,25 @@ func (c *Client) CheckRelation(ctx context.Context, tuple Tuple, contextualTuple
 	return c.checkRelation(ctx, tuple, false, contextualTuples...)
 }
 
+// CheckRelationWithContext behaves like CheckRelation but additionally sets a
+// request-level condition context and supports conditioned contextual tuples.
+func (c *Client) CheckRelationWithContext(ctx context.Context, tuple Tuple, conditionContext map[string]any, contextualTuples ...Tuple) (bool, error) {
+	cr := openfga.NewCheckRequest(*tuple.ToOpenFGACheckRequestTupleKey())
+	cr.SetAuthorizationModelId(c.authModelID)
+	if len(contextualTuples) > 0 {
+		keys := tuplesToOpenFGATupleKeys(contextualTuples)
+		cr.SetContextualTuples(*openfga.NewContextualTupleKeys(keys))
+	}
+	if conditionContext != nil {
+		cr.SetContext(conditionContext)
+	}
+	checkResp, _, err := c.api.Check(ctx, c.storeID).Body(*cr).Execute()
+	if err != nil {
+		return false, fmt.Errorf("cannot check relation: %v", err)
+	}
+	return checkResp.GetAllowed(), nil
+}
+
 // CheckRelationWithTracing verifies that the specified relation exists (either
 // directly or indirectly) between the object and the target as specified by
 // the tuple. This method enables the tracing option.
@@ -417,6 +436,9 @@ func AuthModelFromJSON(data []byte) (*openfga.AuthorizationModel, error) {
 func (c *Client) CreateAuthModel(ctx context.Context, authModel *openfga.AuthorizationModel) (string, error) {
 	ar := openfga.NewWriteAuthorizationModelRequest(authModel.TypeDefinitions, authModel.SchemaVersion)
 	ar.SetSchemaVersion(authModel.SchemaVersion)
+	if authModel.Conditions != nil {
+		ar.SetConditions(*authModel.Conditions)
+	}
 	resp, _, err := c.api.WriteAuthorizationModel(ctx, c.storeID).Body(*ar).Execute()
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("cannot execute WriteAuthorizationModel request: %v", err))

--- a/client_test.go
+++ b/client_test.go
@@ -1480,6 +1480,17 @@ func TestAuthModelFromJson(t *testing.T) {
 func TestClientCreateAuthModel(t *testing.T) {
 	c := qt.New(t)
 	client := getTestClient(c)
+	conditions := map[string]openfga.Condition{
+		"can_grant": {
+			Name:       "can_grant",
+			Expression: "grantable == true",
+			Parameters: &map[string]openfga.ConditionParamTypeRef{
+				"grantable": {TypeName: openfga.TYPENAME_BOOL},
+			},
+		},
+	}
+	authModelWithConditions := authModel
+	authModelWithConditions.Conditions = &conditions
 
 	tests := []struct {
 		about               string
@@ -1506,6 +1517,22 @@ func TestClientCreateAuthModel(t *testing.T) {
 			ExpectedReqBody: &openfga.WriteAuthorizationModelRequest{
 				TypeDefinitions: authModel.TypeDefinitions,
 				SchemaVersion:   authModel.SchemaVersion,
+			},
+			MockResponse: openfga.WriteAuthorizationModelResponse{AuthorizationModelId: "XYZ"},
+		}},
+		expectedAuthModelID: "XYZ",
+	}, {
+		about:     "auth model with conditions is created successfully",
+		authModel: &authModelWithConditions,
+		mockRoutes: []*mockhttp.RouteResponder{{
+			Route: WriteAuthModelRoute,
+			ExpectedPathParams: map[string]string{
+				storeIDPathParam: validFGAParams.StoreID,
+			},
+			ExpectedReqBody: &openfga.WriteAuthorizationModelRequest{
+				TypeDefinitions: authModelWithConditions.TypeDefinitions,
+				SchemaVersion:   authModelWithConditions.SchemaVersion,
+				Conditions:      authModelWithConditions.Conditions,
 			},
 			MockResponse: openfga.WriteAuthorizationModelResponse{AuthorizationModelId: "XYZ"},
 		}},

--- a/example_test.go
+++ b/example_test.go
@@ -190,6 +190,31 @@ func ExampleClient_CheckRelation_contextualTuples() {
 	fmt.Printf("allowed: %v", allowed)
 }
 
+func ExampleClient_CheckRelationWithContext() {
+	contextualTuple := ofga.Tuple{
+		Object:    &ofga.Entity{Kind: "user", ID: "123"},
+		Relation:  "viewer",
+		Target:    &ofga.Entity{Kind: "report", ID: "quarterly"},
+		Condition: ofga.NewRelationshipCondition("can_grant"),
+	}
+
+	allowed, err := client.CheckRelationWithContext(
+		context.Background(),
+		ofga.Tuple{
+			Object:   &ofga.Entity{Kind: "user", ID: "123"},
+			Relation: "viewer",
+			Target:   &ofga.Entity{Kind: "report", ID: "quarterly"},
+		},
+		map[string]any{"grantable": true},
+		contextualTuple,
+	)
+	if err != nil {
+		// Handle err
+		return
+	}
+	fmt.Printf("allowed: %v", allowed)
+}
+
 func ExampleClient_CheckRelationWithTracing() {
 	// Check if the relation exists
 	allowed, err := client.CheckRelationWithTracing(context.Background(), ofga.Tuple{

--- a/integrationtesting/relation_test.go
+++ b/integrationtesting/relation_test.go
@@ -132,3 +132,61 @@ func TestIntegrationRemoveRelationIdempotent(t *testing.T) {
 		t.Fatalf("Expected error when adding duplicate relations, but got none")
 	}
 }
+
+func TestIntegrationCheckRelationWithConditionContext(t *testing.T) {
+	// Setup OpenFGA client and store
+	fgaClient, storeID, modelID := setupTestClient(t)
+	defer func() {
+		// Cleanup: delete the test store
+		_, _ = fgaClient.DeleteStore(t.Context()).Execute()
+	}()
+
+	// Create ofga client wrapper
+	ofgaClient, err := ofga.NewClient(
+		t.Context(),
+		ofga.OpenFGAParams{
+			Scheme:      "http",
+			Host:        "localhost",
+			Port:        "8080",
+			StoreID:     storeID,
+			AuthModelID: modelID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create OpenFGA client: %v", err)
+	}
+
+	checkTuple := ofga.Tuple{
+		Object:   &ofga.Entity{Kind: "user", ID: "alice"},
+		Relation: "viewer",
+		Target:   &ofga.Entity{Kind: "report", ID: "quarterly"},
+	}
+	contextualTuple := checkTuple
+	contextualTuple.Condition = ofga.NewRelationshipCondition("can_grant")
+
+	allowed, err := ofgaClient.CheckRelationWithContext(
+		t.Context(),
+		checkTuple,
+		map[string]any{"grantable": true},
+		contextualTuple,
+	)
+	if err != nil {
+		t.Fatalf("Failed to check relation with condition context: %v", err)
+	}
+	if !allowed {
+		t.Fatalf("Expected conditioned contextual tuple to allow access when grantable is true")
+	}
+
+	allowed, err = ofgaClient.CheckRelationWithContext(
+		t.Context(),
+		checkTuple,
+		map[string]any{"grantable": false},
+		contextualTuple,
+	)
+	if err != nil {
+		t.Fatalf("Failed to check relation with condition context: %v", err)
+	}
+	if allowed {
+		t.Fatalf("Expected conditioned contextual tuple to deny access when grantable is false")
+	}
+}

--- a/integrationtesting/setup_test.go
+++ b/integrationtesting/setup_test.go
@@ -55,6 +55,7 @@ func setupTestClient(t *testing.T) (*client.OpenFgaClient, string, string) {
 	modelResp, err := fgaClient.WriteAuthorizationModel(t.Context()).Body(client.ClientWriteAuthorizationModelRequest{
 		SchemaVersion:   authModel.SchemaVersion,
 		TypeDefinitions: authModel.TypeDefinitions,
+		Conditions:      authModel.Conditions,
 	}).Execute()
 	if err != nil {
 		t.Fatalf("Failed to create authorization model: %v", err)

--- a/integrationtesting/test-model.json
+++ b/integrationtesting/test-model.json
@@ -1,5 +1,16 @@
 {
     "schema_version": "1.1",
+    "conditions": {
+        "can_grant": {
+            "name": "can_grant",
+            "expression": "grantable == true",
+            "parameters": {
+                "grantable": {
+                    "type_name": "TYPE_NAME_BOOL"
+                }
+            }
+        }
+    },
     "type_definitions": [
         {
             "type": "user"
@@ -233,6 +244,26 @@
                         "directly_related_user_types": [
                             {
                                 "type": "user"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "type": "report",
+            "relations": {
+                "viewer": {
+                    "this": {}
+                }
+            },
+            "metadata": {
+                "relations": {
+                    "viewer": {
+                        "directly_related_user_types": [
+                            {
+                                "type": "user",
+                                "condition": "can_grant"
                             }
                         ]
                     }

--- a/tuples.go
+++ b/tuples.go
@@ -31,6 +31,14 @@ func (r Relation) String() string {
 	return string(r)
 }
 
+// RelationshipCondition describes the condition attached to a relationship tuple.
+type RelationshipCondition = openfga.RelationshipCondition
+
+// NewRelationshipCondition creates a relationship condition by name.
+func NewRelationshipCondition(name string) *RelationshipCondition {
+	return openfga.NewRelationshipCondition(name)
+}
+
 // Entity represents an entity/entity-set in OpenFGA.
 // Example: `user:<user-id>`, `org:<org-id>#member`, `document:` (only kind
 // sometimes used in the Read API)
@@ -81,9 +89,10 @@ func ParseEntity(s string) (Entity, error) {
 // need to create object to object relationships. Hence, we chose to use
 // (Object, Relation, Target), as it results in more consistent naming.
 type Tuple struct {
-	Object   *Entity
-	Relation Relation
-	Target   *Entity
+	Object    *Entity
+	Relation  Relation
+	Target    *Entity
+	Condition *RelationshipCondition
 }
 
 // ToOpenFGATupleKey converts our Tuple struct into an OpenFGA TupleKey.
@@ -98,6 +107,9 @@ func (t Tuple) ToOpenFGATupleKey() *openfga.TupleKey {
 		k.SetRelation(t.Relation.String())
 	}
 	k.SetObject(t.Target.String())
+	if t.Condition != nil {
+		k.SetCondition(*t.Condition)
+	}
 	return k
 }
 


### PR DESCRIPTION
# Description

CheckRelationWithContext allows adding context to Check calls. This is necessary to allow the evaluation of conditions.
[conditions](https://openfga.dev/docs/modeling/conditions) are a way to evaluate something during a check using a contextual tuple + context.

 From the integration test is clear to understand how conditions work.
You can define a condition which evaluate what's contained in the context.

In our case the condition is very simple: if the context contains a grantable == true the condition returns true and the check returns true, otherwise it's false.

I'm adding this to ofga because it will be used in JAAS to simplify some code.

From what i see conditions have been enabled from 1.4.0 https://github.com/openfga/openfga/releases/tag/v1.4.0 and we are at least on 1.8.x on `stable`, so it should be supported.

# QA 
the integration tests.