### PR TITLE
feat: add batch check to the openfga client

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,6 +55,7 @@ type OpenFGAParams struct {
 // OpenFgaApi defines the methods of the underlying api client that our Client
 // depends upon.
 type OpenFgaApi interface {
+	BatchCheck(ctx context.Context, storeId string) openfga.ApiBatchCheckRequest
 	Check(ctx context.Context, storeID string) openfga.ApiCheckRequest
 	CreateStore(ctx context.Context) openfga.ApiCreateStoreRequest
 	Expand(ctx context.Context, storeID string) openfga.ApiExpandRequest
@@ -202,6 +203,34 @@ func (c *Client) AddRelation(ctx context.Context, tuples ...Tuple) error {
 // It requires OpenFGA server version >= 1.10.0.
 func (c *Client) AddRelationIdempotent(ctx context.Context, tuples ...Tuple) error {
 	return c.AddRemoveRelationsIdempotent(ctx, tuples, nil)
+}
+
+// BatchCheckRelations checks whether the specified relations exist (either directly or indirectly) between the objects and targets specified by the given tuples.
+// This method returns a map of correlation IDs to boolean values indicating whether the relation exists for each tuple.
+// The correlation ID is used to uniquely identify each tuple in the request and response.
+// This API was introduced in OpenFGA v1.8.0.
+// The maximum number of tuples by default is 50.
+func (c *Client) BatchCheckRelations(ctx context.Context, tuples []TupleWithCorrelationId, contextualTuples ...Tuple) (map[string]bool, error) {
+	bcr := openfga.NewBatchCheckRequest(nil)
+	bcr.SetAuthorizationModelId(c.authModelID)
+
+	checkRequests := make([]openfga.BatchCheckItem, 0, len(tuples))
+	for _, tuple := range tuples {
+		checkRequests = append(checkRequests, *tuple.ToOpenFGABatchCheckItem())
+	}
+	bcr.SetChecks(checkRequests)
+
+	resp, _, err := c.api.BatchCheck(ctx, c.storeID).Body(*bcr).Execute()
+	if err != nil {
+		slog.ErrorContext(ctx, fmt.Sprintf("cannot execute BatchCheck request: %v", err))
+		return nil, fmt.Errorf("cannot batch check relations: %v", err)
+	}
+
+	results := make(map[string]bool, len(resp.GetResult()))
+	for key, result := range resp.GetResult() {
+		results[key] = result.GetAllowed()
+	}
+	return results, nil
 }
 
 // CheckRelation checks whether the specified relation exists (either directly

--- a/integrationtesting/batch_check_test.go
+++ b/integrationtesting/batch_check_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the LGPL license, see LICENSE file for details.
+
+package integration
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/canonical/ofga"
+)
+
+func TestIntegrationBatchCheck(t *testing.T) {
+	// Setup OpenFGA client and store
+	fgaClient, storeID, _ := setupTestClient(t)
+	defer func() {
+		// Cleanup: delete the test store
+		_, _ = fgaClient.DeleteStore(t.Context()).Execute()
+	}()
+
+	// Create ofga client wrapper
+	ofgaClient, err := ofga.NewClient(
+		t.Context(),
+		ofga.OpenFGAParams{
+			Scheme:  "http",
+			Host:    "localhost",
+			Port:    "8080",
+			StoreID: storeID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create OpenFGA client: %v", err)
+	}
+	addTuples := []ofga.Tuple{}
+	// Test: Add relations multiple times
+	for i := range 50 {
+		addTuples = append(addTuples, ofga.Tuple{
+			Object:   &ofga.Entity{Kind: "user", ID: strconv.Itoa(i)},
+			Relation: "editor",
+			Target:   &ofga.Entity{Kind: "document", ID: "ABC"},
+		})
+	}
+	// Add tuples idempotently.
+	err = ofgaClient.AddRemoveRelationsIdempotent(t.Context(), addTuples, nil)
+	if err != nil {
+		t.Fatalf("Failed to add/remove relations idempotently: %v", err)
+	}
+	batchTuples := make([]ofga.TupleWithCorrelationId, 0, len(addTuples))
+	for _, tuple := range addTuples {
+		batchTuples = append(batchTuples, ofga.TupleWithCorrelationId{
+			Tuple:         &tuple,
+			CorrelationId: "correlation_" + tuple.Object.ID,
+		})
+	}
+	results, err := ofgaClient.BatchCheckRelations(t.Context(), batchTuples)
+	if err != nil {
+		t.Fatalf("Failed to batch check relations: %v", err)
+	}
+	// Verify the results
+	for _, tuple := range batchTuples {
+		result, exists := results[tuple.CorrelationId]
+		if !exists {
+			t.Errorf("No result found for correlation ID: %s", tuple.CorrelationId)
+		} else if !result {
+			t.Errorf("Expected relation to exist for correlation ID: %s, but it does not", tuple.CorrelationId)
+		}
+	}
+}
+
+func TestIntegrationCheckMultipleRelations(t *testing.T) {
+	// Setup OpenFGA client and store
+	fgaClient, storeID, _ := setupTestClient(t)
+	defer func() {
+		// Cleanup: delete the test store
+		_, _ = fgaClient.DeleteStore(t.Context()).Execute()
+	}()
+
+	// Create ofga client wrapper
+	ofgaClient, err := ofga.NewClient(
+		t.Context(),
+		ofga.OpenFGAParams{
+			Scheme:  "http",
+			Host:    "localhost",
+			Port:    "8080",
+			StoreID: storeID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create OpenFGA client: %v", err)
+	}
+	addTuples := []ofga.Tuple{}
+	// Test: Add relations multiple times
+	for i := range 100 {
+		addTuples = append(addTuples, ofga.Tuple{
+			Object:   &ofga.Entity{Kind: "user", ID: strconv.Itoa(i)},
+			Relation: "editor",
+			Target:   &ofga.Entity{Kind: "document", ID: "ABC"},
+		})
+	}
+	// Add tuples idempotently.
+	err = ofgaClient.AddRemoveRelationsIdempotent(t.Context(), addTuples, nil)
+	if err != nil {
+		t.Fatalf("Failed to add/remove relations idempotently: %v", err)
+	}
+	for _, tuple := range addTuples {
+		checked, err := ofgaClient.CheckRelation(t.Context(), tuple)
+		if err != nil {
+			t.Fatalf("Failed to check relation for tuple %+v: %v", tuple, err)
+		}
+		if !checked {
+			t.Errorf("Expected relation to exist for tuple %+v, but it does not", tuple)
+		}
+	}
+}

--- a/tuples.go
+++ b/tuples.go
@@ -83,6 +83,12 @@ func ParseEntity(s string) (Entity, error) {
 	}, nil
 }
 
+// TupleWithCorrelationId represents a tuple with an associated correlation ID.
+type TupleWithCorrelationId struct {
+	*Tuple
+	CorrelationId string
+}
+
 // Tuple represents a relation between an object and a target. Note that OpenFGA
 // represents a Tuple as (User, Relation, Object). However, the `User` field is
 // not restricted to just being users, it could also refer to objects when we
@@ -118,6 +124,13 @@ func (t Tuple) ToOpenFGATupleKey() *openfga.TupleKey {
 func (t Tuple) ToOpenFGACheckRequestTupleKey() *openfga.CheckRequestTupleKey {
 	tk := t.ToOpenFGATupleKey()
 	return openfga.NewCheckRequestTupleKey(tk.User, tk.Relation, tk.Object)
+}
+
+// ToOpenFGACheckRequestTupleKey converts our Tuple struct into an
+// OpenFGA CheckRequestTupleKey.
+func (t TupleWithCorrelationId) ToOpenFGABatchCheckItem() *openfga.BatchCheckItem {
+	tk := t.ToOpenFGATupleKey()
+	return openfga.NewBatchCheckItem(*openfga.NewCheckRequestTupleKey(tk.User, tk.Relation, tk.Object), t.CorrelationId)
 }
 
 // ToOpenFGAExpandRequestTupleKey converts our Tuple struct into an


### PR DESCRIPTION
## Description

Adding the BatchCheck api method, to improve the performance of checking multiple relations and  solve this TODO i've left in JIMM.

https://github.com/SimoneDutto/jimm/blob/make-jaas-query-models-faster/internal/jimm/permissions/relations.go#L190-L194

BatchCheck were introduced in v1.8.0
https://github.com/openfga/openfga/releases/tag/v1.8.0

And the openfga deployed in ps7 is on 1.8.4, so we could immidiately leverage that.

The difference between the two integration tests (one checking one at the time, and the other using the batch check) at runtime is 0.385s vs 0.09s. So the perf improvement would be quite significant.

