### PR TITLE
feat: wire contextual tuple for batch checks

### DIFF
--- a/client.go
+++ b/client.go
@@ -208,9 +208,10 @@ func (c *Client) AddRelationIdempotent(ctx context.Context, tuples ...Tuple) err
 // BatchCheckRelations checks whether the specified relations exist (either directly or indirectly) between the objects and targets specified by the given tuples.
 // This method returns a map of correlation IDs to boolean values indicating whether the relation exists for each tuple.
 // The correlation ID is used to uniquely identify each tuple in the request and response.
+// Contextual tuples are scoped per item via TupleWithCorrelationId.ContextualTuples.
 // This API was introduced in OpenFGA v1.8.0.
 // The maximum number of tuples by default is 50.
-func (c *Client) BatchCheckRelations(ctx context.Context, tuples []TupleWithCorrelationId, contextualTuples ...Tuple) (map[string]bool, error) {
+func (c *Client) BatchCheckRelations(ctx context.Context, tuples []TupleWithCorrelationId) (map[string]bool, error) {
 	bcr := openfga.NewBatchCheckRequest(nil)
 	bcr.SetAuthorizationModelId(c.authModelID)
 

--- a/integrationtesting/batch_check_test.go
+++ b/integrationtesting/batch_check_test.go
@@ -67,6 +67,63 @@ func TestIntegrationBatchCheck(t *testing.T) {
 	}
 }
 
+func TestIntegrationBatchCheckWithContextualTuples(t *testing.T) {
+	// Setup OpenFGA client and store
+	fgaClient, storeID, _ := setupTestClient(t)
+	defer func() {
+		// Cleanup: delete the test store
+		_, _ = fgaClient.DeleteStore(t.Context()).Execute()
+	}()
+
+	// Create ofga client wrapper
+	ofgaClient, err := ofga.NewClient(
+		t.Context(),
+		ofga.OpenFGAParams{
+			Scheme:  "http",
+			Host:    "localhost",
+			Port:    "8080",
+			StoreID: storeID,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to create OpenFGA client: %v", err)
+	}
+
+	// The relation only exists as a contextual (non-persistent) tuple.
+	relation := ofga.Tuple{
+		Object:   &ofga.Entity{Kind: "user", ID: "alice"},
+		Relation: "editor",
+		Target:   &ofga.Entity{Kind: "document", ID: "readme"},
+	}
+
+	// Without the contextual tuple, the relation should be denied.
+	checkWithoutContext := ofga.TupleWithCorrelationId{
+		Tuple:         &relation,
+		CorrelationId: "without-context",
+	}
+	// With the contextual tuple attached to this item, it should be allowed.
+	checkWithContext := ofga.TupleWithCorrelationId{
+		Tuple:            &relation,
+		CorrelationId:    "with-context",
+		ContextualTuples: []ofga.Tuple{relation},
+	}
+
+	results, err := ofgaClient.BatchCheckRelations(t.Context(), []ofga.TupleWithCorrelationId{
+		checkWithoutContext,
+		checkWithContext,
+	})
+	if err != nil {
+		t.Fatalf("Failed to batch check relations: %v", err)
+	}
+
+	if results[checkWithoutContext.CorrelationId] {
+		t.Errorf("Expected relation to be denied without its contextual tuple")
+	}
+	if !results[checkWithContext.CorrelationId] {
+		t.Errorf("Expected relation to be allowed with its contextual tuple")
+	}
+}
+
 func TestIntegrationCheckMultipleRelations(t *testing.T) {
 	// Setup OpenFGA client and store
 	fgaClient, storeID, _ := setupTestClient(t)

--- a/tuples.go
+++ b/tuples.go
@@ -84,9 +84,13 @@ func ParseEntity(s string) (Entity, error) {
 }
 
 // TupleWithCorrelationId represents a tuple with an associated correlation ID.
+// ContextualTuples are temporary, non-persistent relationship tuples that are
+// scoped to this individual check item, mirroring the per-item
+// `contextual_tuples` field of an OpenFGA BatchCheckItem.
 type TupleWithCorrelationId struct {
 	*Tuple
-	CorrelationId string
+	CorrelationId    string
+	ContextualTuples []Tuple
 }
 
 // Tuple represents a relation between an object and a target. Note that OpenFGA
@@ -126,11 +130,16 @@ func (t Tuple) ToOpenFGACheckRequestTupleKey() *openfga.CheckRequestTupleKey {
 	return openfga.NewCheckRequestTupleKey(tk.User, tk.Relation, tk.Object)
 }
 
-// ToOpenFGACheckRequestTupleKey converts our Tuple struct into an
-// OpenFGA CheckRequestTupleKey.
+// ToOpenFGABatchCheckItem converts our TupleWithCorrelationId struct into an
+// OpenFGA BatchCheckItem, including any per-item contextual tuples.
 func (t TupleWithCorrelationId) ToOpenFGABatchCheckItem() *openfga.BatchCheckItem {
 	tk := t.ToOpenFGATupleKey()
-	return openfga.NewBatchCheckItem(*openfga.NewCheckRequestTupleKey(tk.User, tk.Relation, tk.Object), t.CorrelationId)
+	item := openfga.NewBatchCheckItem(*openfga.NewCheckRequestTupleKey(tk.User, tk.Relation, tk.Object), t.CorrelationId)
+	if len(t.ContextualTuples) > 0 {
+		keys := tuplesToOpenFGATupleKeys(t.ContextualTuples)
+		item.SetContextualTuples(*openfga.NewContextualTupleKeys(keys))
+	}
+	return item
 }
 
 // ToOpenFGAExpandRequestTupleKey converts our Tuple struct into an


### PR DESCRIPTION
## Description

Originally in the PR i've added contextual tuples because i thought they will eventually get supported but they were supported out of the box.

I was wrong and they are supported right now from the beginning of BatchCheck.

It's technically a breaking change, but I've released the batch check today, so i will just do a fix release.

